### PR TITLE
Refactored Websocket Error

### DIFF
--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -63,7 +63,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
             (_, state) = get_party_of_user(user.id)
         except NotInPartyError:
             await self.send_json(
-                event.error("You are currently not in the party")
+                event.initially_not_joined()
             )
             return
 
@@ -96,15 +96,15 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
             try:
                 await command(msg)
             except KeyError:
-                await self.send_json(event.error('Invalid data'))
+                await self.send_json(event.error.invalid_data())
             except Party.DoesNotExist:
-                await self.send_json(event.error('Party does not exist'))
+                await self.send_json(event.error.invalid_party())
             except NotInPartyError:
-                await self.send_json(event.error('You are currently not in the party'))
+                await self.send_json(event.error.not_joined())
             except AlreadyJoinedError:
-                await self.send_json(event.error('You are already joined to a party'))
+                await self.send_json(event.error.already_joined())
         else:
-            await self.send_json(event.error('Invalid command'))
+            await self.send_json(event.error.invalid_command())
 
     async def command_party_join(self, msg):
         user = self.scope['user']

--- a/backend/websocket/event/__init__.py
+++ b/backend/websocket/event/__init__.py
@@ -1,13 +1,3 @@
-from .models import PartyState
-
-
-def error(cause: str):
-    return {
-        'type': 'error',
-        'error': cause,
-    }
-
-
 def party_join(user_id: int):
     return {
         'type': 'party.join',
@@ -38,8 +28,14 @@ def menu_unassign(user_id: int, menu_id: int):
     }
 
 
-def state_update(state: PartyState):
+def state_update(state):
     return {
         'type': 'state.update',
         'state': state.as_dict(),
+    }
+
+
+def initially_not_joined():
+    return {
+        'type': 'initial.not.joined',
     }

--- a/backend/websocket/event/__init__.py
+++ b/backend/websocket/event/__init__.py
@@ -1,3 +1,6 @@
+from . import error
+
+
 def party_join(user_id: int):
     return {
         'type': 'party.join',

--- a/backend/websocket/event/error.py
+++ b/backend/websocket/event/error.py
@@ -1,0 +1,28 @@
+def invalid_command():
+    return {
+        'type': 'error.invalid.command',
+    }
+
+
+def invalid_data():
+    return {
+        'type': 'error.invalid.data',
+    }
+
+
+def invalid_party():
+    return {
+        'type': 'error.invalid.party',
+    }
+
+
+def not_joined():
+    return {
+        'type': 'error.not.joined',
+    }
+
+
+def already_joined():
+    return {
+        'type': 'error.already.joined',
+    }

--- a/backend/websocket/tests.py
+++ b/backend/websocket/tests.py
@@ -132,7 +132,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'data': 'bar',
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error('Invalid command'))
+        self.assertDictEqual(resp, event.error.invalid_command())
 
     @async_test
     async def test_invalid_data(self):
@@ -143,7 +143,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'foo': 'bar',
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error('Invalid data'))
+        self.assertDictEqual(resp, event.error.invalid_data())
 
     @async_test
     async def test_party_join(self):
@@ -173,7 +173,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'party_id': 0,
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error('Party does not exist'))
+        self.assertDictEqual(resp, event.error.invalid_party())
 
     @async_test
     async def test_party_join_state_does_not_exist(self):
@@ -188,7 +188,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'party_id': party_id,
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error('Party does not exist'))
+        self.assertDictEqual(resp, event.error.invalid_party())
 
     @async_test
     async def test_party_leave_and_deleted(self):
@@ -217,8 +217,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'command': 'party.leave',
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error(
-            'You are currently not in the party'))
+        self.assertDictEqual(resp, event.error.not_joined())
 
     @async_test
     async def test_party_leave_does_not_exist(self):
@@ -233,7 +232,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'command': 'party.leave',
         })
         resp = await communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error('Party does not exist'))
+        self.assertDictEqual(resp, event.error.invalid_party())
 
     @async_test
     async def test_party_leave_deleted_state(self):
@@ -258,8 +257,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
             'party_id': self.party.id,
         })
         resp = await self.communicator.receive_json_from(1)
-        self.assertDictEqual(resp, event.error(
-            'You are already joined to a party'))
+        self.assertDictEqual(resp, event.error.already_joined())
 
     @async_test
     async def test_already_joined_connection(self):


### PR DESCRIPTION
- Error as event
- If not joined to party on connection, send `initial.not.joined` rather than `error.not.joined`
