### PR TITLE
Renaming irrelevant names in Websocket models and APIs

### DIFF
--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -181,16 +181,16 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
     async def command_menu_create(self, data):
         menu_id = data['menu_id']
         quantity = data['quantity']
-        users = data['users']
+        user_ids = data['user_ids']
 
         (party, state) = get_party_of_user(self.scope['user'].id)
 
-        menu_entry_id = state.menus.add(menu_id, quantity, users)
+        menu_entry_id = state.menus.add(menu_id, quantity, user_ids)
         state.save()
 
         await self.channel_layer.group_send(
             'party-{}'.format(party.id),
-            event.menu_create(menu_entry_id, menu_id, quantity, users),
+            event.menu_create(menu_entry_id, menu_id, quantity, user_ids),
         )
 
     async def command_menu_update(self, data):
@@ -203,7 +203,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
 
         try:
             state.menus.update(
-                menu_entry_id, quantity, add_users=add_user_ids, remove_users=remove_user_ids)
+                menu_entry_id, quantity, add_user_ids=add_user_ids, remove_user_ids=remove_user_ids)
         except KeyError:
             await self.send_json(
                 event.error.invalid_menu_entry()
@@ -254,10 +254,10 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
         menu_entry_id = data['menu_entry_id']
         menu_id = data['menu_id']
         quantity = data['quantity']
-        users = data['users']
+        user_ids = data['user_ids']
 
         await self.send_json(
-            event.menu_create(menu_entry_id, menu_id, quantity, users)
+            event.menu_create(menu_entry_id, menu_id, quantity, user_ids)
         )
 
     async def menu_update(self, data):

--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -124,7 +124,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
 
         # TODO: Check party permission
 
-        state.members.append(user_id)
+        state.member_ids.append(user_id)
         party.member_count += 1
         state.save()
         party.save()
@@ -149,7 +149,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
         (party, state) = get_party_of_user(user_id)
         party_id = party.id
 
-        state.members.remove(user_id)
+        state.member_ids.remove(user_id)
         party.member_count -= 1
         state.save()
         party.save()
@@ -167,7 +167,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
             )
 
             if party.leader.id == user_id:
-                next_user_id = state.members[0]
+                next_user_id = state.member_ids[0]
                 user = User.objects.get(id=next_user_id)
                 party.leader = user
                 party.save()

--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -185,7 +185,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
 
         (party, state) = get_party_of_user(self.scope['user'].id)
 
-        menu_entry_id = state.menus.add(menu_id, quantity, user_ids)
+        menu_entry_id = state.menu_entries.add(menu_id, quantity, user_ids)
         state.save()
 
         await self.channel_layer.group_send(
@@ -202,7 +202,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
         (party, state) = get_party_of_user(self.scope['user'].id)
 
         try:
-            state.menus.update(
+            state.menu_entries.update(
                 menu_entry_id, quantity, add_user_ids=add_user_ids, remove_user_ids=remove_user_ids)
         except KeyError:
             await self.send_json(
@@ -223,7 +223,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
         (party, state) = get_party_of_user(self.scope['user'].id)
 
         try:
-            state.menus.delete(menu_entry_id)
+            state.menu_entries.delete(menu_entry_id)
         except KeyError:
             await self.send_json(
                 event.error.invalid_menu_entry()

--- a/backend/websocket/event/__init__.py
+++ b/backend/websocket/event/__init__.py
@@ -15,13 +15,13 @@ def party_leave(user_id: int):
     }
 
 
-def menu_create(menu_entry_id: int, menu_id: int, quantity: int, users: list):
+def menu_create(menu_entry_id: int, menu_id: int, quantity: int, user_ids: list):
     return {
         'type': 'menu.create',
         'menu_entry_id': menu_entry_id,
         'menu_id': menu_id,
         'quantity': quantity,
-        'users': users,
+        'user_ids': user_ids,
     }
 
 

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -41,7 +41,7 @@ class PartyState(CacheModel):
         self.phase = PartyPhase.ChoosingMenu
         self.restaurant = None
         self.member_ids = []
-        self.menus = MenuEntries()
+        self.menu_entries = MenuEntries()
 
     @classmethod
     def get(cls, id: int):
@@ -60,7 +60,7 @@ class PartyState(CacheModel):
         self.phase = o['phase']
         self.restaurant = o.get('restaurant', None)
         self.member_ids = o['member_ids']
-        self.menus = MenuEntries.from_dict(o['menus'])
+        self.menu_entries = MenuEntries.from_dict(o['menu_entries'])
 
     def as_dict(self):
         return {
@@ -68,7 +68,7 @@ class PartyState(CacheModel):
             'phase': self.phase,
             'restaurant': self.restaurant,
             'member_ids': self.member_ids,
-            'menus': self.menus.as_dict() if isinstance(self.menus, MenuEntries) else self.menus,
+            'menu_entries': self.menu_entries.as_dict() if isinstance(self.menu_entries, MenuEntries) else self.menu_entries,
         }
 
 

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -91,9 +91,9 @@ class MenuEntries:
     def as_dict(self):
         return self.inner
 
-    def add(self, menu_id: int, quantity: int, users: list):
+    def add(self, menu_id: int, quantity: int, user_ids: list):
         id = self.last_id + 1
-        self.inner[id] = ((menu_id, quantity, users))
+        self.inner[id] = ((menu_id, quantity, user_ids))
         self.last_id = id
         return id
 
@@ -103,11 +103,11 @@ class MenuEntries:
     def get(self, menu_entry_id: int, default=None):
         return self.inner.get(menu_entry_id, default)
 
-    def update(self, menu_entry_id: int, quantity: int, add_users=[], remove_users=[]):
+    def update(self, menu_entry_id: int, quantity: int, add_user_ids=[], remove_user_ids=[]):
         (m, q, ul) = self.inner[menu_entry_id]
         q += quantity
-        ul.extend(add_users)
-        for u in remove_users:
+        ul.extend(add_user_ids)
+        for u in remove_user_ids:
             ul.remove(u)
         self.inner[menu_entry_id] = (m, q, ul)
         return self.inner[menu_entry_id]

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -68,7 +68,8 @@ class PartyState(CacheModel):
             'phase': self.phase,
             'restaurant_id': self.restaurant_id,
             'member_ids': self.member_ids,
-            'menu_entries': self.menu_entries.as_dict() if isinstance(self.menu_entries, MenuEntries) else self.menu_entries,
+            'menu_entries': self.menu_entries.as_dict() if isinstance(
+                self.menu_entries, MenuEntries) else self.menu_entries,
         }
 
 

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -39,7 +39,7 @@ class PartyState(CacheModel):
         self.id = party_id
         # TODO: Change to ChoosingRestaurant
         self.phase = PartyPhase.ChoosingMenu
-        self.restaurant = None
+        self.restaurant_id = None
         self.member_ids = []
         self.menu_entries = MenuEntries()
 
@@ -58,7 +58,7 @@ class PartyState(CacheModel):
         super().refresh_from_db()
         o = super().get(self.id)
         self.phase = o['phase']
-        self.restaurant = o.get('restaurant', None)
+        self.restaurant_id = o.get('restaurant_id', None)
         self.member_ids = o['member_ids']
         self.menu_entries = MenuEntries.from_dict(o['menu_entries'])
 
@@ -66,7 +66,7 @@ class PartyState(CacheModel):
         return {
             'id': self.id,
             'phase': self.phase,
-            'restaurant': self.restaurant,
+            'restaurant_id': self.restaurant_id,
             'member_ids': self.member_ids,
             'menu_entries': self.menu_entries.as_dict() if isinstance(self.menu_entries, MenuEntries) else self.menu_entries,
         }

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -40,7 +40,7 @@ class PartyState(CacheModel):
         # TODO: Change to ChoosingRestaurant
         self.phase = PartyPhase.ChoosingMenu
         self.restaurant = None
-        self.members = []
+        self.member_ids = []
         self.menus = MenuEntries()
 
     @classmethod
@@ -59,7 +59,7 @@ class PartyState(CacheModel):
         o = super().get(self.id)
         self.phase = o['phase']
         self.restaurant = o.get('restaurant', None)
-        self.members = o['members']
+        self.member_ids = o['member_ids']
         self.menus = MenuEntries.from_dict(o['menus'])
 
     def as_dict(self):
@@ -67,7 +67,7 @@ class PartyState(CacheModel):
             'id': self.id,
             'phase': self.phase,
             'restaurant': self.restaurant,
-            'members': self.members,
+            'member_ids': self.member_ids,
             'menus': self.menus.as_dict() if isinstance(self.menus, MenuEntries) else self.menus,
         }
 

--- a/backend/websocket/tests.py
+++ b/backend/websocket/tests.py
@@ -404,7 +404,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         id1 = resp['menu_entry_id']
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_create(id1, 11, 1, [user1.id]))
-        self.assertTupleEqual(state.menus.get(id1), (11, 1, [user1.id]))
+        self.assertTupleEqual(state.menu_entries.get(id1), (11, 1, [user1.id]))
 
         await communicator2.send_json_to({
             'command': 'menu.create',
@@ -417,8 +417,8 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         id2 = resp['menu_entry_id']
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_create(id2, 11, 1, [user2.id]))
-        self.assertTupleEqual(state.menus.get(id2), (11, 1, [user2.id]))
-        self.assertDictEqual(state.menus.inner, {
+        self.assertTupleEqual(state.menu_entries.get(id2), (11, 1, [user2.id]))
+        self.assertDictEqual(state.menu_entries.inner, {
             id1: (11, 1, [user1.id]),
             id2: (11, 1, [user2.id]),
         })
@@ -431,7 +431,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         communicator1 = self.communicator1
         communicator2 = self.communicator2
         state = party.state
-        state.menus.inner = {1: (11, 1, [user1.id])}
+        state.menu_entries.inner = {1: (11, 1, [user1.id])}
         state.save()
 
         await self.join_both()
@@ -445,7 +445,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         resp = await communicator1.receive_json_from(1)
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_update(1, 1, [], []))
-        self.assertTupleEqual(state.menus.get(1), (11, 2, [user1.id]))
+        self.assertTupleEqual(state.menu_entries.get(1), (11, 2, [user1.id]))
 
         await communicator1.send_json_to({
             'command': 'menu.update',
@@ -458,7 +458,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_update(1, 1, [user2.id], []))
         self.assertTupleEqual(
-            state.menus.get(1), (11, 3, [user1.id, user2.id]))
+            state.menu_entries.get(1), (11, 3, [user1.id, user2.id]))
 
         await communicator2.send_json_to({
             'command': 'menu.update',
@@ -470,7 +470,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         resp = await communicator1.receive_json_from(1)
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_update(1, -2, [], [user1.id]))
-        self.assertTupleEqual(state.menus.get(1), (11, 1, [user2.id]))
+        self.assertTupleEqual(state.menu_entries.get(1), (11, 1, [user2.id]))
 
         await communicator2.send_json_to({
             'command': 'menu.update',
@@ -489,7 +489,8 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         communicator1 = self.communicator1
         communicator2 = self.communicator2
         state = party.state
-        state.menus.inner = {1: (11, 1, [user1.id]), 2: (22, 2, [user2.id])}
+        state.menu_entries.inner = {
+            1: (11, 1, [user1.id]), 2: (22, 2, [user2.id])}
         state.save()
 
         await self.join_both()
@@ -502,8 +503,9 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         resp = await communicator1.receive_json_from(1)
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_delete(1))
-        self.assertIsNone(state.menus.get(1))
-        self.assertDictEqual(state.menus.inner, {2: (22, 2, [user2.id])})
+        self.assertIsNone(state.menu_entries.get(1))
+        self.assertDictEqual(state.menu_entries.inner,
+                             {2: (22, 2, [user2.id])})
 
         await communicator1.send_json_to({
             'command': 'menu.delete',
@@ -513,8 +515,8 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         resp = await communicator2.receive_json_from(1)
         state.refresh_from_db()
         self.assertDictEqual(resp, event.menu_delete(2))
-        self.assertIsNone(state.menus.get(2))
-        self.assertDictEqual(state.menus.inner, {})
+        self.assertIsNone(state.menu_entries.get(2))
+        self.assertDictEqual(state.menu_entries.inner, {})
 
         await communicator2.send_json_to({
             'command': 'menu.delete',

--- a/backend/websocket/tests.py
+++ b/backend/websocket/tests.py
@@ -161,7 +161,7 @@ class SingleWebsocketTestCase(TestCaseWithCache):
 
         party.refresh_from_db()
         self.assertDictEqual(resp, event.state_update(party.state))
-        self.assertEqual(party.state.members[0], user.id)
+        self.assertEqual(party.state.member_ids[0], user.id)
         self.assertEqual(party.member_count, 1)
         self.assertEqual(cache.get('user-party:{}'.format(user.id)), party_id)
 
@@ -377,8 +377,8 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
         self.assertDictEqual(resp, event.party_leave(user2.id))
 
         party.refresh_from_db()
-        self.assertEqual(len(party.state.members), 1)
-        self.assertEqual(party.state.members[0], user1.id)
+        self.assertEqual(len(party.state.member_ids), 1)
+        self.assertEqual(party.state.member_ids[0], user1.id)
         self.assertEqual(party.member_count, 1)
         self.assertIsNone(cache.get('user-party:{}'.format(user2.id)))
 

--- a/backend/websocket/tests.py
+++ b/backend/websocket/tests.py
@@ -397,7 +397,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
             'command': 'menu.create',
             'menu_id': 11,
             'quantity': 1,
-            'users': [user1.id],
+            'user_ids': [user1.id],
         })
         await communicator1.receive_json_from(1)
         resp = await communicator2.receive_json_from(1)
@@ -410,7 +410,7 @@ class DoubleWebsocketTestCase(TestCaseWithCache):
             'command': 'menu.create',
             'menu_id': 11,
             'quantity': 1,
-            'users': [user2.id],
+            'user_ids': [user2.id],
         })
         await communicator2.receive_json_from(1)
         resp = await communicator1.receive_json_from(1)
@@ -590,9 +590,9 @@ class MenuEntriesTestCase(TestCase):
 
         self.entries.update(1, 1)
         self.assertDictEqual(self.entries.inner, {1: (1, 2, [1])})
-        self.entries.update(1, 1, add_users=[2])
+        self.entries.update(1, 1, add_user_ids=[2])
         self.assertDictEqual(self.entries.inner, {1: (1, 3, [1, 2])})
-        self.entries.update(1, -2, remove_users=[1])
+        self.entries.update(1, -2, remove_user_ids=[1])
         self.assertDictEqual(self.entries.inner, {1: (1, 1, [2])})
         with self.assertRaises(KeyError):
             self.entries.update(2, 1)


### PR DESCRIPTION
- `users` -> `user_ids`
- `members` -> `member_ids`
- `menus` -> `menu_entries`
- `restaurant` -> `restaurant_id`
