### PR TITLE
Backend iss97

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -91,7 +91,8 @@ class PartyRecord(models.Model):
     members = models.ManyToManyField(User, related_name='party_records')
     restaurant = models.ForeignKey(
         Restaurant, null=True, on_delete=models.SET_NULL)
-    paid_user = models.ForeignKey(User, null=True, on_delete=models.SET_NULL)
+    paid_user = models.ForeignKey(
+        User, blank=True, null=True, on_delete=models.SET_NULL)
 
     def as_dict(self):
         return {

--- a/backend/api/tests/test_party.py
+++ b/backend/api/tests/test_party.py
@@ -139,6 +139,22 @@ class PartyTestCase(TestCaseWithHttp):
         state.delete()
         party.delete()
 
+    def test_delete_party_with_invalid_state(self):
+        party = Party(
+            name="new party name",
+            type=int(PartyType.Private),
+            location="new party location",
+            leader=self.user,
+        )
+        party.save()
+        id = party.id
+
+        self.login()
+
+        party.state.delete()
+        resp = self.delete('/api/party/{}/'.format(id))
+        self.assertEqual(resp.status_code, 200)
+
     def test_get_party_detail(self):
         self.login()
 

--- a/backend/api/tests/test_record.py
+++ b/backend/api/tests/test_record.py
@@ -2,6 +2,7 @@ from django.test import Client
 
 from . import TestCaseWithHttp
 from api.models import User, Party, PartyType, Restaurant, Menu, PartyRecord, Payment
+from api.util import make_record
 from websocket.models import PartyState, PartyPhase
 
 
@@ -52,11 +53,7 @@ class RecordTestCase(TestCaseWithHttp):
 
     def test_create_record(self):
         state = self.party.state
-        state.delete()
-
-        self.assertTrue(PartyRecord.objects.all().exists())
-
-        record = PartyRecord.objects.all()[0]
+        record = make_record(state)
 
         self.assertEqual(record.name, self.party.name)
         self.assertEqual(record.type, self.party.type)
@@ -99,8 +96,7 @@ class RecordTestCase(TestCaseWithHttp):
         self.assertEqual(self.get('/api/collections/').status_code, 403)
 
     def test_get_records(self):
-        self.party.state.delete()
-        record = PartyRecord.objects.all()[0]
+        record = make_record(self.party.state)
 
         self.login()
 
@@ -110,8 +106,7 @@ class RecordTestCase(TestCaseWithHttp):
         self.assertEqual(resp_json[0]['id'], record.id)
 
     def test_get_payments(self):
-        self.party.state.delete()
-        record = PartyRecord.objects.all()[0]
+        record = make_record(self.party.state)
 
         self.login()
 
@@ -125,8 +120,7 @@ class RecordTestCase(TestCaseWithHttp):
         )
 
     def test_get_collections(self):
-        self.party.state.delete()
-        record = PartyRecord.objects.all()[0]
+        record = make_record(self.party.state)
 
         self.login()
 
@@ -140,8 +134,7 @@ class RecordTestCase(TestCaseWithHttp):
         )
 
     def test_resolve_payment(self):
-        self.party.state.delete()
-        record = PartyRecord.objects.all()[0]
+        record = make_record(self.party.state)
 
         super().login(email="pbzweihander@rustaceans.org", password="iluvrust2")
 

--- a/backend/api/tests/test_record.py
+++ b/backend/api/tests/test_record.py
@@ -69,10 +69,10 @@ class RecordTestCase(TestCaseWithHttp):
 
         for payment in payments:
             self.assertTrue(payment.user_id in [self.user1.id, self.user3.id])
-            self.assertEqual(payment.paid_user.id, self.user2.id)
-            if payment.menu.id == self.menu1.id:
+            self.assertEqual(payment.paid_user_id, self.user2.id)
+            if payment.menu_id == self.menu1.id:
                 self.assertEqual(payment.price, self.menu1.price)
-            elif payment.menu.id == self.menu2.id:
+            elif payment.menu_id == self.menu2.id:
                 self.assertEqual(payment.price, self.menu2.price / 3)
             else:
                 self.assertEqual(payment.price, self.menu3.price * 2)
@@ -145,7 +145,7 @@ class RecordTestCase(TestCaseWithHttp):
             resp = self.get('/api/resolve_payment/{}/'.format(payment.id))
             self.assertEqual(resp.status_code, 200)
 
-        self.assertFalse(Payment.objects.filter(resolved=False).exists())
+        self.assertFalse(record.payments.filter(resolved=False).exists())
 
         resp = self.get('/api/collections/')
         self.assertListEqual(resp.json(), [])
@@ -158,3 +158,15 @@ class RecordTestCase(TestCaseWithHttp):
         resp = client.get(
             '/api/resolve_payment/{}/'.format(record.payments.all()[0].id))
         self.assertEqual(resp.status_code, 403)
+
+    def test_create_record_without_paid_user(self):
+        state = self.party.state
+        state.paid_user_id = None
+        record = make_record(state)
+
+        self.assertEqual(record.paid_user, None)
+
+        payments = record.payments.all()
+
+        for payment in payments:
+            self.assertEqual(payment.paid_user, None)

--- a/backend/api/tests/test_record.py
+++ b/backend/api/tests/test_record.py
@@ -36,6 +36,7 @@ class RecordTestCase(TestCaseWithHttp):
 
         state = self.party.state
         state.member_ids = [self.user1.id, self.user2.id, self.user3.id]
+        state.member_ids_backup = [self.user1.id, self.user2.id, self.user3.id]
         state.menu_entries.add(
             self.menu1.id, 3, [self.user1.id, self.user2.id, self.user3.id])
         state.menu_entries.add(
@@ -70,7 +71,7 @@ class RecordTestCase(TestCaseWithHttp):
         payments = record.payments.all()
 
         for payment in payments:
-            self.assertTrue(payment.user.id in [self.user1.id, self.user3.id])
+            self.assertTrue(payment.user_id in [self.user1.id, self.user3.id])
             self.assertEqual(payment.paid_user.id, self.user2.id)
             if payment.menu.id == self.menu1.id:
                 self.assertEqual(payment.price, self.menu1.price)

--- a/backend/api/tests/test_record.py
+++ b/backend/api/tests/test_record.py
@@ -170,3 +170,12 @@ class RecordTestCase(TestCaseWithHttp):
 
         for payment in payments:
             self.assertEqual(payment.paid_user, None)
+
+    def test_create_record_with_api(self):
+        super().login(email="ferris@rustaceans.org", password="iluvrust")
+
+        records_length = PartyRecord.objects.all().count()
+
+        self.delete('/api/party/{}/'.format(self.party.id))
+
+        self.assertEqual(PartyRecord.objects.all().count() - records_length, 1)

--- a/backend/api/util.py
+++ b/backend/api/util.py
@@ -12,11 +12,13 @@ def make_payments(state: PartyState, record: PartyRecord):
             price = (menu.price * quantity) / (len(user_ids))
             payment = Payment(
                 user_id=user_id,
-                paid_user_id=state.paid_user_id,
                 menu=menu,
                 price=price,
                 party_record_id=record.id,
             )
+            if state.paid_user_id:
+                payment.paid_user_id = state.paid_user_id
+            payment.save()
             payments.append(payment)
     for payment in payments:
         payment.save()
@@ -32,8 +34,9 @@ def make_record(state: PartyState):
         leader_id=party.leader_id,
         since=party.since,
         restaurant_id=state.restaurant_id,
-        paid_user_id=state.paid_user_id,
     )
+    if state.paid_user_id:
+        record.paid_user_id = state.paid_user_id
     record.save()
     record.members.set(User.objects.filter(id__in=state.member_ids))
     record.save()

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -10,6 +10,7 @@ from json.decoder import JSONDecodeError
 from .models import User, Party, PartyType, Restaurant, Menu, Payment
 from .decorator import allow_authenticated, allow_method
 from .decorator import get_menu, get_party, get_payment, get_restaurant
+from .util import make_record
 
 
 @allow_method(['POST'])
@@ -100,6 +101,9 @@ def party_detail(request: HttpRequest, party: Party):
         if party.leader != request.user:
             return HttpResponseForbidden()
 
+        state = party.state
+        if state is not None:
+            make_record(state)
         party.delete()
 
         return HttpResponse()

--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -5,6 +5,7 @@ import json
 
 from .models import PartyState, PartyPhase
 from api.models import Party, User, Restaurant, Menu
+from api.util import make_record
 from websocket import event, exception
 
 WEBSOCKET_REJECT_UNAUTHORIZED = 4000
@@ -186,6 +187,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
                     event.leader_change(next_user_id),
                 )
         else:
+            make_record(state)
             party.delete()
 
     async def command_to_choosing_menu(self, data):

--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -159,6 +159,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
         party_id = party.id
 
         state.member_ids.remove(user_id)
+        state.menu_entries.remove_user(user_id)
         party.member_count -= 1
         state.save()
         party.save()

--- a/backend/websocket/consumer.py
+++ b/backend/websocket/consumer.py
@@ -219,6 +219,7 @@ class WebsocketConsumer(AsyncJsonWebsocketConsumer):
             raise exception.NotAuthorizedError
 
         state.phase = PartyPhase.Ordering
+        state.member_ids_backup = state.member_ids[:]
         state.save()
 
         await self.channel_layer.group_send(

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -56,13 +56,6 @@ class PartyState(CacheModel):
 
         return self
 
-    def delete(self):
-        if self.phase >= PartyPhase.Ordering:
-            from api.util import make_record
-            self.member_ids = self.member_ids_backup[:]
-            make_record(self)
-        super().delete()
-
     def refresh_from_db(self):
         super().refresh_from_db()
         o = super().get(self.id)

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -41,7 +41,8 @@ class PartyState(CacheModel):
         self.restaurant_id = None
         self.restaurant_votes = []
         self.member_ids = []
-        self.paid_user_id = []
+        self.member_ids_backup = []
+        self.paid_user_id = None
         self.menu_entries = MenuEntries()
 
     @classmethod
@@ -56,8 +57,9 @@ class PartyState(CacheModel):
         return self
 
     def delete(self):
-        if self.phase == PartyPhase.PaymentAndCollection:
+        if self.phase >= PartyPhase.Ordering:
             from api.util import make_record
+            self.member_ids = self.member_ids_backup[:]
             make_record(self)
         super().delete()
 
@@ -68,6 +70,7 @@ class PartyState(CacheModel):
         self.restaurant_id = o.get('restaurant_id', None)
         self.restaurant_votes = o.get('restaurant_votes', [])
         self.member_ids = o.get('member_ids', [])
+        self.member_ids_backup = o.get('member_ids_backup', [])
         self.paid_user_id = o.get('paid_user_id', None)
         self.menu_entries = MenuEntries.from_dict(o['menu_entries'])
 
@@ -78,6 +81,7 @@ class PartyState(CacheModel):
             'restaurant_id': self.restaurant_id,
             'restaurant_votes': self.restaurant_votes,
             'member_ids': self.member_ids,
+            'member_ids_backup': self.member_ids_backup,
             'paid_user_id': self.paid_user_id,
             'menu_entries': self.menu_entries.as_dict() if isinstance(
                 self.menu_entries, MenuEntries) else self.menu_entries,

--- a/backend/websocket/models.py
+++ b/backend/websocket/models.py
@@ -119,6 +119,12 @@ class MenuEntries:
     def get(self, menu_entry_id: int, default=None):
         return self.inner.get(menu_entry_id, default)
 
+    def remove_user(self, user_id: int):
+        for k in self.inner:
+            (m, q, ul) = self.inner[k]
+            ul = [u for u in ul if u != user_id]
+            self.inner[k] = (m, q, ul)
+
     def update(self, menu_entry_id: int, quantity: int, add_user_ids=[], remove_user_ids=[]):
         (m, q, ul) = self.inner[menu_entry_id]
         q += quantity

--- a/backend/websocket/tests/test_menu.py
+++ b/backend/websocket/tests/test_menu.py
@@ -220,9 +220,36 @@ class MenuTestCase2(TestCaseWithDoubleWebsocket):
             'command': 'menu.delete',
             'menu_entry_id': 3,
         })
-        await communicator1.receive_nothing()
+        await communicator1.receive_nothing(1)
         resp = await communicator2.receive_json_from(1)
         self.assertDictEqual(resp, event.error.invalid_menu_entry())
+
+    @async_test
+    async def test_leaving_party(self):
+        user1 = self.user1
+        user2 = self.user2
+        party = self.party
+        communicator2 = self.communicator2
+        state = party.state
+        state.menu_entries.inner = {
+            1: (self.menu1.id, 1, [user1.id]), 2: (self.menu2.id, 2, [user2.id])}
+        state.save()
+
+        await self.join_both()
+
+        await communicator2.send_json_to({
+            'command': 'party.leave',
+        })
+        await communicator2.receive_nothing(1)
+
+        state.refresh_from_db()
+        self.assertDictEqual(
+            state.menu_entries.inner,
+            {
+                1: (self.menu1.id, 1, [user1.id]),
+                2: (self.menu2.id, 2, [])
+            },
+        )
 
 
 class MenuEntriesTestCase(TestCase):


### PR DESCRIPTION
Resolved #97 

- Remove user from menu entries when user leaves party
- Seperate making party record and deleting party state
- Backup party members when switching to ordering phase, so even if user leaves party after ordering phase, can make party record and payments properly
