### PR TITLE
Frontend lobby css

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -21,7 +21,15 @@ import { UserItemComponent } from './party/party-ordered/user-item/user-item.com
 import { VoteRestaurantComponent } from './party/party-choosing-restaurant/vote-restaurant/vote-restaurant.component';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatBadgeModule, MatButtonModule, MatIconModule, MatInputModule, MatListModule, MatSnackBarModule } from '@angular/material';
+import {
+  MatBadgeModule,
+  MatButtonModule, MatCheckboxModule,
+  MatDialogModule,
+  MatIconModule,
+  MatInputModule,
+  MatListModule, MatRadioModule,
+  MatSnackBarModule
+} from '@angular/material';
 
 @NgModule({
   declarations: [
@@ -57,6 +65,11 @@ import { MatBadgeModule, MatButtonModule, MatIconModule, MatInputModule, MatList
     MatListModule,
     MatIconModule,
     MatBadgeModule,
+    MatDialogModule,
+    MatRadioModule,
+  ],
+  entryComponents: [
+    PartyCreateComponent,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { VoteRestaurantComponent } from './party/party-choosing-restaurant/vote-
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
   MatBadgeModule,
-  MatButtonModule, MatCheckboxModule,
+  MatButtonModule,
   MatDialogModule,
   MatIconModule,
   MatInputModule,

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -21,7 +21,7 @@ import { UserItemComponent } from './party/party-ordered/user-item/user-item.com
 import { VoteRestaurantComponent } from './party/party-choosing-restaurant/vote-restaurant/vote-restaurant.component';
 
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatButtonModule, MatInputModule, MatSnackBarModule } from '@angular/material';
+import { MatBadgeModule, MatButtonModule, MatIconModule, MatInputModule, MatListModule, MatSnackBarModule } from '@angular/material';
 
 @NgModule({
   declarations: [
@@ -54,6 +54,9 @@ import { MatButtonModule, MatInputModule, MatSnackBarModule } from '@angular/mat
     MatInputModule,
     MatButtonModule,
     MatSnackBarModule,
+    MatListModule,
+    MatIconModule,
+    MatBadgeModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.css
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.css
@@ -1,0 +1,29 @@
+button {
+  content: 'block';
+  width: 100%;
+  height: 100%;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.left {
+  margin-top: auto;
+  margin-bottom: auto;
+  font-size: x-large;
+}
+
+.right {
+  max-width: 20%;
+}
+
+.member-count {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
@@ -3,14 +3,14 @@
         (click)="joinPartyButton(party.id);">
   <div class="container">
     <div class="left">
-      <span>{{party.name}}</span>
+      <span id="party-name">{{party.name}}</span>
     </div>
     <div class="right">
       <div class="member-count">
         <mat-icon color="primary">account_circle</mat-icon>
-        <span>{{party.memberCount}}</span>
+        <span id="party-member-count">{{party.memberCount}}</span>
       </div>
-      <span>@{{party.location}}</span>
+      <span id="party-location">@{{party.location}}</span>
     </div>
   </div>
 </button>
@@ -19,14 +19,14 @@
         (click)="navigateToPartyButton();">
   <div class="container">
     <div class="left">
-      <span matBadge="My" matBadgeOverlap="false" matBadgeColor="accent">{{party.name}}</span>
+      <span matBadge="My" matBadgeOverlap="false" matBadgeColor="accent" id="selected-party-name">{{party.name}}</span>
     </div>
     <div class="right">
       <div class="member-count">
         <mat-icon color="primary">account_circle</mat-icon>
-        <span>{{party.memberCount}}</span>
+        <span id="selected-party-member-count">{{party.memberCount}}</span>
       </div>
-      <span>@{{party.location}}</span>
+      <span id="selected-party-location">@{{party.location}}</span>
     </div>
   </div>
 </button>

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
@@ -1,3 +1,33 @@
-<span id="party-id">{{party.id}}</span> <span id="party-name">{{party.name}}</span>
-<button *ngIf="!this.joinedPartyId" (click)="joinPartyButton(party.id);">Join</button>
-<button *ngIf="this.joinedPartyId === this.party.id" (click)="navigateToPartyButton();">Join</button>
+<button mat-button
+        *ngIf="this.joinedPartyId != this.party.id"
+        (click)="joinPartyButton(party.id);">
+  <div class="container">
+    <div class="left">
+      {{party.name}}
+    </div>
+    <div class="right">
+      <div class="member-count">
+        <mat-icon color="primary">account_circle</mat-icon>
+        <span>{{party.memberCount}}</span>
+      </div>
+      <span>@{{party.location}}</span>
+    </div>
+  </div>
+</button>
+<button mat-button
+        *ngIf="this.joinedPartyId === this.party.id"
+        (click)="navigateToPartyButton();">
+  <div class="container">
+    <div class="left">
+      <span matBadge="My" matBadgeOverlap="false" matBadgeColor="accent">{{party.name}}</span>
+    </div>
+    <div class="right">
+      <div class="member-count">
+        <mat-icon>account_circle</mat-icon>
+        <span>{{party.memberCount}}</span>
+      </div>
+      <span>@{{party.location}}</span>
+    </div>
+  </div>
+</button>
+

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
@@ -23,7 +23,7 @@
     </div>
     <div class="right">
       <div class="member-count">
-        <mat-icon>account_circle</mat-icon>
+        <mat-icon color="primary">account_circle</mat-icon>
         <span>{{party.memberCount}}</span>
       </div>
       <span>@{{party.location}}</span>

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
@@ -3,7 +3,7 @@
         (click)="joinPartyButton(party.id);">
   <div class="container">
     <div class="left">
-      {{party.name}}
+      <span>{{party.name}}</span>
     </div>
     <div class="right">
       <div class="member-count">

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.spec.ts
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.spec.ts
@@ -5,6 +5,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { LobbyListItemComponent } from './lobby-list-item.component';
 import { Party, PartyType } from '../../types/party';
+import { MatBadgeModule, MatButtonModule, MatIconModule } from '@angular/material';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const mockLobbyListItem: Party = {
   id: 1,
@@ -25,6 +27,10 @@ describe('LobbyListItemComponent', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule,
+        BrowserAnimationsModule,
+        MatButtonModule,
+        MatBadgeModule,
+        MatIconModule,
       ],
       declarations: [LobbyListItemComponent],
     })
@@ -42,11 +48,15 @@ describe('LobbyListItemComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have as id 1', () => {
-    expect(fixture.nativeElement.querySelector('#party-id').textContent).toEqual(String(component.party.id));
-  });
-
   it(`should have as name 'Name 1'`, () => {
     expect(fixture.nativeElement.querySelector('#party-name').textContent).toEqual(component.party.name);
+  });
+
+  it(`should have as member count 1`, () => {
+    expect(fixture.nativeElement.querySelector('#party-member-count').textContent).toEqual(String(component.party.memberCount));
+  });
+
+  it(`should have as location '@Location 1'`, () => {
+    expect(fixture.nativeElement.querySelector('#party-location').textContent).toEqual('@' + component.party.location);
   });
 });

--- a/frontend/src/app/lobby/lobby.component.css
+++ b/frontend/src/app/lobby/lobby.component.css
@@ -1,0 +1,19 @@
+mat-list-item {
+  height: 100% !important;
+}
+
+app-lobby-list-item {
+  content: 'block';
+  width: 100%;
+}
+
+.fixed {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}
+
+button {
+  align-items: center;
+  align-content: center;
+}

--- a/frontend/src/app/lobby/lobby.component.html
+++ b/frontend/src/app/lobby/lobby.component.html
@@ -8,10 +8,12 @@
     </mat-list-item>
   </mat-list>
   <div class="fixed">
-    <button mat-mini-fab color="accent" *ngIf="!joinedPartyId" (click)="showPartyCreate();">
+    <button mat-mini-fab color="accent" *ngIf="!joinedPartyId" (click)="showPartyCreateDialog();">
       <mat-icon>add</mat-icon>
     </button>
   </div>
+  <!--
   <app-party-create *ngIf="isShowingPartyCreate" (createParty)="createParty($event);" (cancel)="hidePartyCreate();">
   </app-party-create>
+  -->
 </div>

--- a/frontend/src/app/lobby/lobby.component.html
+++ b/frontend/src/app/lobby/lobby.component.html
@@ -1,13 +1,16 @@
 <div>
-  <div>
-    <li *ngFor="let party of parties">
+  <mat-list>
+    <mat-list-item *ngFor="let party of parties; last as last">
       <app-lobby-list-item [party]="party" [joinedPartyId]="joinedPartyId" (joinParty)="joinParty($event);"
-        (navigateToParty)="navigateToParty();">
+                           (navigateToParty)="navigateToParty();">
       </app-lobby-list-item>
-    </li>
-  </div>
-  <div>
-    <button *ngIf="!joinedPartyId" (click)="showPartyCreate();">Create Party</button>
+      <mat-divider [inset]="true" *ngIf="!last"></mat-divider>
+    </mat-list-item>
+  </mat-list>
+  <div class="fixed">
+    <button mat-mini-fab color="accent" *ngIf="!joinedPartyId" (click)="showPartyCreate();">
+      <mat-icon>add</mat-icon>
+    </button>
   </div>
   <app-party-create *ngIf="isShowingPartyCreate" (createParty)="createParty($event);" (cancel)="hidePartyCreate();">
   </app-party-create>

--- a/frontend/src/app/lobby/lobby.component.html
+++ b/frontend/src/app/lobby/lobby.component.html
@@ -12,8 +12,4 @@
       <mat-icon>add</mat-icon>
     </button>
   </div>
-  <!--
-  <app-party-create *ngIf="isShowingPartyCreate" (createParty)="createParty($event);" (cancel)="hidePartyCreate();">
-  </app-party-create>
-  -->
 </div>

--- a/frontend/src/app/lobby/lobby.component.spec.ts
+++ b/frontend/src/app/lobby/lobby.component.spec.ts
@@ -10,6 +10,8 @@ import { UserService } from '../services/user.service';
 
 import { Party, PartyType, PartyCreateRequest, PartyState, MenuEntryCreateRequest, MenuEntryUpdateRequest } from '../types/party';
 import { User } from '../types/user';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatDialog, MatIconModule, MatListModule } from '@angular/material';
 
 const mockUser: User = {
   id: 1,
@@ -81,6 +83,9 @@ describe('LobbyComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         FormsModule,
+        BrowserAnimationsModule,
+        MatListModule,
+        MatIconModule,
       ],
       declarations: [
         LobbyComponent,
@@ -91,6 +96,7 @@ describe('LobbyComponent', () => {
         { provide: PartyService, useClass: MockPartyService },
         { provide: UserService, useValue: userSpy },
         { provide: Router, useValue: routerSpy },
+        { provide: MatDialog, useValue: {} },
       ],
     }).compileComponents();
 

--- a/frontend/src/app/lobby/lobby.component.ts
+++ b/frontend/src/app/lobby/lobby.component.ts
@@ -5,6 +5,8 @@ import { PartyService } from '../services/party.service';
 
 import { Party, PartyCreateRequest, PartyState } from '../types/party';
 import { Subscription } from 'rxjs';
+import { MatDialog } from '@angular/material';
+import { PartyCreateComponent } from './party-create/party-create.component';
 
 @Component({
   selector: 'app-lobby',
@@ -14,12 +16,12 @@ import { Subscription } from 'rxjs';
 export class LobbyComponent implements OnInit, OnDestroy {
   parties: Party[];
   joinedPartyId = undefined;
-  isShowingPartyCreate = false;
   subscriptions: Subscription[] = [];
 
   constructor(
     private partyService: PartyService,
     private router: Router,
+    public dialog: MatDialog,
   ) { }
 
   ngOnInit() {
@@ -51,12 +53,17 @@ export class LobbyComponent implements OnInit, OnDestroy {
     this.partyService.getParties().then(parties => this.parties = parties);
   }
 
-  showPartyCreate(): void {
-    this.isShowingPartyCreate = true;
-  }
+  showPartyCreateDialog(): void {
+    const dialogRef = this.dialog.open(PartyCreateComponent, {
+      width: '90%',
+      maxWidth: '350px'
+    });
 
-  hidePartyCreate(): void {
-    this.isShowingPartyCreate = false;
+    dialogRef.afterClosed().subscribe(result => {
+      if (result != null) {
+        this.createParty(result);
+      }
+    });
   }
 
   createParty(req: PartyCreateRequest): void {

--- a/frontend/src/app/lobby/party-create/party-create.component.css
+++ b/frontend/src/app/lobby/party-create/party-create.component.css
@@ -1,0 +1,25 @@
+.input {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+}
+
+.radio {
+  margin-right: 10px;
+}
+
+h3 {
+  margin-bottom: -5px;
+  text-align: center;
+}
+
+mat-form-field {
+  margin: 10px 0;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-bottom: -12px !important;
+}

--- a/frontend/src/app/lobby/party-create/party-create.component.html
+++ b/frontend/src/app/lobby/party-create/party-create.component.html
@@ -1,18 +1,20 @@
-<div>
-  <div>
-    <input type="text" [(ngModel)]="party.name" placeholder="Name" autofocus>
-  </div>
-  <div>
-    <select [(ngModel)]="party.type">
-      <option value="0">In Group</option>
-      <option value="1">Private</option>
-    </select>
-  </div>
-  <div>
-    <input type="text" [(ngModel)]="party.location" placeholder="Location" autofocus>
-  </div>
-  <div>
-    <button (click)="cancelButton();">Cancel</button>
-    <button (click)="createButton();">Create</button>
-  </div>
+<h3 mat-dialog-title>Create New Party</h3>
+  <section class="input">
+    <mat-form-field>
+      <input matInput type="text" [(ngModel)]="name" placeholder="Name">
+    </mat-form-field>
+    <div class="radio-group">
+      <label class="radio">Type:</label>
+        <mat-radio-group [(ngModel)]="type">
+          <mat-radio-button class="radio" value="0">In Group</mat-radio-button>
+          <mat-radio-button class="radio" value="1">Private</mat-radio-button>
+      </mat-radio-group>
+    </div>
+    <mat-form-field>
+      <input matInput type="text" [(ngModel)]="location" placeholder="Location">
+    </mat-form-field>
+  </section>
+<div class="buttons" mat-dialog-actions>
+  <button mat-raised-button color="primary" (click)="tryCreateParty()">Create</button>
+  <button mat-raised-button color="primary" (click)="onNoClick()">Cancel</button>
 </div>

--- a/frontend/src/app/lobby/party-create/party-create.component.spec.ts
+++ b/frontend/src/app/lobby/party-create/party-create.component.spec.ts
@@ -2,6 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { PartyCreateComponent } from './party-create.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { MatButtonModule, MatDialogModule, MatDialogRef, MatInputModule, MatRadioModule } from '@angular/material';
 
 describe('PartyCreateComponent', () => {
   let component: PartyCreateComponent;
@@ -9,8 +11,21 @@ describe('PartyCreateComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [FormsModule],
+      imports: [
+        FormsModule,
+        BrowserAnimationsModule,
+        MatInputModule,
+        MatButtonModule,
+        MatDialogModule,
+        MatRadioModule,
+      ],
       declarations: [PartyCreateComponent],
+      providers: [
+        {
+          provide: MatDialogRef,
+          useValue: {}
+        },
+      ]
     })
       .compileComponents();
   }));

--- a/frontend/src/app/lobby/party-create/party-create.component.ts
+++ b/frontend/src/app/lobby/party-create/party-create.component.ts
@@ -1,6 +1,7 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import {Component, OnInit, Output, EventEmitter, Inject} from '@angular/core';
 
-import { PartyType, PartyCreateRequest } from '../../types/party';
+import { PartyCreateRequest, PartyType} from '../../types/party';
+import { MatDialogRef } from '@angular/material';
 
 @Component({
   selector: 'app-party-create',
@@ -8,31 +9,27 @@ import { PartyType, PartyCreateRequest } from '../../types/party';
   styleUrls: ['./party-create.component.css']
 })
 export class PartyCreateComponent implements OnInit {
-  @Output() createParty: EventEmitter<PartyCreateRequest> = new EventEmitter();
-  @Output() cancel: EventEmitter<void> = new EventEmitter();
 
-  party: PartyCreateRequest = {
-    name: '',
-    type: PartyType.InGroup,
-    location: '',
-  };
-  submitting = false;
+  name: string;
+  type: PartyType;
+  location: string;
 
-  constructor() { }
+  constructor(public dialogRef: MatDialogRef<PartyCreateComponent>) { }
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
 
   ngOnInit() {
   }
 
-  cancelButton() {
-    this.cancel.emit();
-  }
-
-  createButton() {
-    if (this.submitting) {
-      return;
+  tryCreateParty(): void {
+    if (this.name && this.type && this.location) {
+      const req = new PartyCreateRequest();
+      req.name = this.name;
+      req.type = this.type;
+      req.location = this.location;
+      this.dialogRef.close(req);
     }
-    this.submitting = true;
-
-    this.createParty.emit(this.party);
   }
 }

--- a/frontend/src/app/sign-in/sign-in.component.css
+++ b/frontend/src/app/sign-in/sign-in.component.css
@@ -10,8 +10,9 @@
   font-size: xx-large;
 }
 
-.full-width {
+mat-form-field {
   width: 100%;
+  margin-top: 20px;
 }
 
 .sign-up {

--- a/frontend/src/app/sign-in/sign-in.component.css
+++ b/frontend/src/app/sign-in/sign-in.component.css
@@ -1,5 +1,6 @@
 .main {
-  width: 40%;
+  width: 70%;
+  max-width: 400px;
   margin: 20% auto;
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/sign-in/sign-in.component.html
+++ b/frontend/src/app/sign-in/sign-in.component.html
@@ -1,11 +1,11 @@
 <div class="main">
   <span class="title">Moyobob</span>
-  <mat-form-field class="full-width">
+  <mat-form-field>
     <input matInput type="text" [(ngModel)]="emailInput" (keypress)="trySignIn($event);"
            placeholder="email" autofocus />
   </mat-form-field>
 
-  <mat-form-field class="full-width">
+  <mat-form-field>
     <input matInput type="password" [(ngModel)]="passwordInput" (keypress)="trySignIn($event);"
            placeholder="password" />
   </mat-form-field>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -8,6 +8,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
* Fixed little design of `Sign In`
* Designed `Lobby`
* Change create party another page to dialog
* Tests are little modified just to pass... need complex testing further

Current CSS
- Sign In
<img width="723" alt="2018-12-09 3 25 08" src="https://user-images.githubusercontent.com/42956097/49689298-96ca3080-fb62-11e8-9292-ae3c50f7021d.png">
- Lobby
<img width="724" alt="2018-12-09 3 26 26" src="https://user-images.githubusercontent.com/42956097/49689309-b8c3b300-fb62-11e8-8da6-0c072cd62604.png">
- Lobby with Joined Party
<img width="725" alt="2018-12-09 3 26 43" src="https://user-images.githubusercontent.com/42956097/49689314-c4af7500-fb62-11e8-9047-abb2d3c09b32.png">
- Create Party
<img width="722" alt="2018-12-09 3 27 31" src="https://user-images.githubusercontent.com/42956097/49689316-cda04680-fb62-11e8-8a03-d886b7b3c7b8.png">
- Create Party with Input
<img width="721" alt="2018-12-09 3 27 59" src="https://user-images.githubusercontent.com/42956097/49689321-d6911800-fb62-11e8-8331-6d2f41d3822b.png">
