### PR TITLE
Fixed dockerization

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,4 +17,4 @@ COPY backend backend
 
 EXPOSE 8000
 
-CMD daphne -b 0.0.0.0 -p 8000 backend.asgi:application
+CMD uvicorn --host 0.0.0.0 --port 8000 backend.asgi:application

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -14,13 +14,13 @@ services:
     restart: unless-stopped
 
   backend:
-    build: .
+    image: pbzweihander/moyobob-backend:latest
     restart: unless-stopped
     depends_on:
       - redis
       - postgres
     ports:
-      - 127.0.0.1:8000:8000
+      - "8000:8000"
     env_file:
       - /srv/moyobob/backend/env
     volumes:


### PR DESCRIPTION
- Use uvicorn instead of daphne
- Use docker hub automated build
- Use docker hub image
