### PR TITLE
add ellipsis when party name and/or party location is long

### DIFF
--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.css
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.css
@@ -15,6 +15,7 @@ button {
   margin-top: auto;
   margin-bottom: auto;
   font-size: x-large;
+  text-align: left;
 }
 
 .right {
@@ -26,4 +27,10 @@ button {
   flex-direction: row;
   justify-content: flex-end;
   align-items: center;
+}
+
+.ellipsis {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.html
@@ -1,11 +1,9 @@
-<button mat-button
-        *ngIf="this.joinedPartyId != this.party.id"
-        (click)="joinPartyButton(party.id);">
+<button mat-button (click)="joinPartyButton(party.id);">
   <div class="container">
-    <div class="left">
+    <div class="left ellipsis">
       <span id="party-name">{{party.name}}</span>
     </div>
-    <div class="right">
+    <div class="right ellipsis">
       <div class="member-count">
         <mat-icon color="primary">account_circle</mat-icon>
         <span id="party-member-count">{{party.memberCount}}</span>
@@ -14,20 +12,3 @@
     </div>
   </div>
 </button>
-<button mat-button
-        *ngIf="this.joinedPartyId === this.party.id"
-        (click)="navigateToPartyButton();">
-  <div class="container">
-    <div class="left">
-      <span matBadge="My" matBadgeOverlap="false" matBadgeColor="accent" id="selected-party-name">{{party.name}}</span>
-    </div>
-    <div class="right">
-      <div class="member-count">
-        <mat-icon color="primary">account_circle</mat-icon>
-        <span id="selected-party-member-count">{{party.memberCount}}</span>
-      </div>
-      <span id="selected-party-location">@{{party.location}}</span>
-    </div>
-  </div>
-</button>
-

--- a/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.ts
+++ b/frontend/src/app/lobby/lobby-list-item/lobby-list-item.component.ts
@@ -19,10 +19,11 @@ export class LobbyListItemComponent implements OnInit {
   ngOnInit() { }
 
   joinPartyButton(partyId: number) {
-    this.joinParty.emit(partyId);
+    if (this.joinedPartyId === this.party.id) {
+      this.navigateToParty.emit();
+    } else {
+      this.joinParty.emit(partyId);
+    }
   }
 
-  navigateToPartyButton() {
-    this.navigateToParty.emit();
-  }
 }


### PR DESCRIPTION
This PR:
* adds `text-overflow: ellipsis` property to show `...` when text is long